### PR TITLE
Allow for falsy `useFetch`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resift",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "resift",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resift",
-  "version": "0.0.1-alpha.2",
+  "version": "0.0.1-alpha.3",
   "description": "A state management for data fetches in React",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "resift",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1-alpha.2",
   "description": "A state management for data fetches in React",
   "main": "index.js",
   "scripts": {

--- a/src/useFetch/useFetch.d.ts
+++ b/src/useFetch/useFetch.d.ts
@@ -8,6 +8,6 @@ type PickResult<FetchResult, MergeResult> = unknown extends MergeResult
   : Unwrap<MergeResult>;
 
 export default function useFetch<FetchResult, MergeResult>(
-  fetch: FetchActionCreator<any, FetchResult, MergeResult>,
+  fetch: null | FetchActionCreator<any, FetchResult, MergeResult>,
   options?: GetFetchOptions,
 ): [PickResult<FetchResult, MergeResult> | null, number];

--- a/src/useFetch/useFetch.js
+++ b/src/useFetch/useFetch.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import getFetch from '../getFetch';
 import shallowEqual from '../shallowEqual';
 import UNKNOWN from '../UNKNOWN';
+import _get from 'lodash/get';
 
 const neverCalculated = '__NEVER_CALCULATED__';
 const emptyResult = [null, UNKNOWN];
@@ -22,14 +23,14 @@ function memoize(fn) {
 }
 
 export default function useFetch(fetch, options) {
-  const memoizedGetFetch = useMemo(() => memoize(getFetch), [
-    fetch.meta.fetchFactoryId,
-    fetch.meta.key,
-  ]);
+  const fetchFactoryId = _get(fetch, ['meta', 'fetchFactoryId'], 'EMPTY_FETCH');
+  const key = _get(fetch, ['meta', 'key'], 'EMPTY_KEY');
+
+  const memoizedGetFetch = useMemo(() => memoize(getFetch), [fetchFactoryId, key]);
 
   const selector = useCallback(state => memoizedGetFetch(fetch, state, options), [
-    fetch.meta.fetchFactoryId,
-    fetch.meta.key,
+    fetchFactoryId,
+    key,
   ]);
 
   return useSelector(fetch ? selector : emptySelector);

--- a/src/useFetch/useFetch.js
+++ b/src/useFetch/useFetch.js
@@ -2,8 +2,11 @@ import { useMemo, useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import getFetch from '../getFetch';
 import shallowEqual from '../shallowEqual';
+import UNKNOWN from '../UNKNOWN';
 
 const neverCalculated = '__NEVER_CALCULATED__';
+const emptyResult = [null, UNKNOWN];
+const emptySelector = () => emptyResult;
 
 function memoize(fn) {
   let previous = neverCalculated;
@@ -29,5 +32,5 @@ export default function useFetch(fetch, options) {
     fetch.meta.key,
   ]);
 
-  return useSelector(selector);
+  return useSelector(fetch ? selector : emptySelector);
 }

--- a/src/useFetch/useFetch.test.js
+++ b/src/useFetch/useFetch.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import renderer, { act } from 'react-test-renderer';
 import { createStore } from 'redux';
 
@@ -7,6 +7,9 @@ import defineFetch from '../defineFetch';
 import createActionType from '../createActionType';
 import SUCCESS from '../prefixes/SUCCESS';
 import dataServiceReducer from '../dataServiceReducer';
+import DeferredPromise from '../DeferredPromise';
+import createDataService from '../createDataService';
+import ResiftProvider from '../ResiftProvider';
 
 import useFetch from './useFetch';
 
@@ -58,13 +61,13 @@ test('it gets the fetch and returns the data and status', () => {
   const injectedProps = MockComponent.mock.calls[0][0];
 
   expect(injectedProps).toMatchInlineSnapshot(`
-Object {
-  "data": Object {
-    "mock": "data",
-  },
-  "status": 1,
-}
-`);
+    Object {
+      "data": Object {
+        "mock": "data",
+      },
+      "status": 1,
+    }
+  `);
 });
 
 test('it bails out of updating if the data does not change', () => {
@@ -138,4 +141,42 @@ test('it bails out of updating if the data does not change', () => {
 
   expect(MockComponent).toHaveBeenCalledTimes(1);
   expect(mockStoreHandler).toHaveBeenCalledTimes(amountToDispatchOtherAction);
+});
+
+test('accepts falsy value', async () => {
+  const gotResult = new DeferredPromise();
+  const handleError = jest.fn();
+
+  const dataService = createDataService({
+    services: {},
+    onError: handleError,
+  });
+
+  function ExampleComponent() {
+    const result = useFetch(null);
+
+    useEffect(() => {
+      gotResult.resolve(result);
+    }, [result]);
+
+    return <div>example</div>;
+  }
+
+  await act(async () => {
+    renderer.create(
+      <ResiftProvider dataService={dataService}>
+        <ExampleComponent />
+      </ResiftProvider>,
+    );
+
+    await gotResult;
+  });
+
+  const result = await gotResult;
+  expect(result).toMatchInlineSnapshot(`
+    Array [
+      null,
+      0,
+    ]
+  `);
 });


### PR DESCRIPTION
I've encountered a situation where I want to call `useFetch` conditionally.

However, because of the rules of hooks, I can't do that. So instead, let's allow `useFetch` to take in `null` and return `[null, UNKNOWN]` as the result array.

Here is my use case:

![image](https://user-images.githubusercontent.com/10551026/63345113-044c7480-c320-11e9-97ee-944d8c270024.png)

Let me know what you think!