### PR TITLE
Feature/remove key array

### DIFF
--- a/src/clearFetch/clearFetch.test.js
+++ b/src/clearFetch/clearFetch.test.js
@@ -8,7 +8,6 @@ test('it creates a clear fetch action from a fetch with a dynamic key', () => {
   const makePersonFetch = defineFetch({
     displayName: 'person fetch',
     make: personId => ({
-      key: [personId],
       request: () => ({ exampleService }) => exampleService(personId),
     }),
   });
@@ -36,7 +35,6 @@ test('it creates a clear fetch action from a fetch with a static key', () => {
   const makeTestFetch = defineFetch({
     displayName: 'test fetch',
     make: () => ({
-      key: [],
       request: () => ({ exampleService }) => exampleService(),
     }),
   });
@@ -64,7 +62,6 @@ test('it throws if you try to use a dynamic key like a static key', () => {
   const personFetch = defineFetch({
     displayName: 'person fetch',
     make: personId => ({
-      key: [personId],
       request: () => ({ exampleService }) => exampleService(personId),
     }),
   });

--- a/src/createActionType/createActionType.test.js
+++ b/src/createActionType/createActionType.test.js
@@ -10,7 +10,6 @@ test('it takes in a fetch action and returns an action type string', () => {
   const makeActionCreator = defineFetch({
     displayName: 'example fetch',
     make: () => ({
-      key: [],
       request: exampleArg => ({ exampleService }) => exampleService(exampleArg),
     }),
   });

--- a/src/createContextFetch/createContextFetch.test.js
+++ b/src/createContextFetch/createContextFetch.test.js
@@ -31,7 +31,6 @@ test('createContextFetch hooks', async () => {
   const makeFetch = defineFetch({
     displayName: 'Get Example Fetch',
     make: id => ({
-      key: [id],
       request: x => () => ({ exampleValue: x }),
     }),
   });
@@ -92,7 +91,6 @@ test('createContextFetch hooks throws when there is no context value', async () 
   const makeFetch = defineFetch({
     displayName: 'Example',
     make: () => ({
-      key: [],
       request: () => () => {},
     }),
   });
@@ -130,7 +128,6 @@ test('render props/no hooks API', async () => {
   const makeFetch = defineFetch({
     displayName: 'Get Example Fetch',
     make: id => ({
-      key: [id],
       request: x => () => ({ exampleValue: x }),
     }),
   });

--- a/src/createContextFetch/createContextFetch.types-test.tsx
+++ b/src/createContextFetch/createContextFetch.types-test.tsx
@@ -11,7 +11,6 @@ import createContextFetch from './createContextFetch';
   const makeFetch = defineFetch({
     displayName: 'Get Example',
     make: (id: string) => ({
-      key: [id],
       request: (x: number) => ({ http }) =>
         http({
           method: 'GET',

--- a/src/createDataService/createDataService.test.js
+++ b/src/createDataService/createDataService.test.js
@@ -61,7 +61,6 @@ describe('middleware', () => {
     const fetchFactory = defineFetch({
       displayName: 'example fetch',
       make: () => ({
-        key: [],
         request: () => () => {},
       }),
     });
@@ -98,7 +97,6 @@ describe('middleware', () => {
     const makeFetch = defineFetch({
       displayName: 'example fetch',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ testService }) => testService(testArg),
       }),
     });
@@ -159,7 +157,6 @@ Object {
     const makeActionCreator = defineFetch({
       displayName: 'example fetch',
       make: testArg => ({
-        key: [testArg],
         request: () => async ({ testService }) => {
           await timer(0);
           throw testError;
@@ -204,7 +201,6 @@ describe('handleAction', () => {
     const makeActionCreator = defineFetch({
       displayName: 'test action',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(),
       }),
     });
@@ -250,7 +246,6 @@ Object {
     const makeActionCreator = defineFetch({
       displayName: 'test dispatch service',
       make: () => ({
-        key: [],
         request: () => ({ dispatch }) => {
           dispatch({ type: 'TEST_TYPE' });
           return null;
@@ -274,7 +269,6 @@ Object {
     const makeActionCreator = defineFetch({
       displayName: 'action creator',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(testArg),
       }),
       conflict: 'ignore',
@@ -316,7 +310,6 @@ Object {
     const makeActionCreator = defineFetch({
       displayName: 'action creator',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(testArg),
       }),
     });
@@ -366,7 +359,6 @@ Object {
     const makeActionCreator = defineFetch({
       displayName: 'action creator',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(testArg),
       }),
     });
@@ -427,7 +419,6 @@ Object {
     const makeActionCreator = defineFetch({
       displayName: 'action creator',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(testArg),
       }),
     });
@@ -501,7 +492,6 @@ describe('isSuccessAction', () => {
     const makeActionCreator = defineFetch({
       displayName: 'test',
       make: testArg => ({
-        key: [testArg],
         request: () => () => {},
       }),
     });
@@ -524,7 +514,6 @@ describe('isErrorAction', () => {
     const makeActionCreator = defineFetch({
       displayName: 'test',
       make: testArg => ({
-        key: [testArg],
         request: () => () => {},
       }),
     });

--- a/src/dataServiceReducer/actionsReducer.test.js
+++ b/src/dataServiceReducer/actionsReducer.test.js
@@ -21,7 +21,6 @@ test('when given a fetch action, it adds an inflight payload to the store', () =
   const makeFetch = defineFetch({
     displayName: 'example fetch',
     make: testArg => ({
-      key: [testArg],
       request: () => ({ exampleService }) => exampleService(testArg),
     }),
   });
@@ -57,7 +56,6 @@ test('when given a success action, it adds a success payload and replaces the in
   const makeActionCreator = defineFetch({
     displayName: 'example action',
     make: testArg => ({
-      key: [testArg],
       request: () => ({ exampleService }) => exampleService(testArg),
     }),
   });
@@ -107,7 +105,6 @@ test('when given a clear action, it removes the sub-store', () => {
   const makeFetch = defineFetch({
     displayName: 'example action',
     make: testArg => ({
-      key: [testArg],
       request: () => ({ exampleService }) => exampleService(testArg),
     }),
   });
@@ -211,7 +208,6 @@ test('when given an error action, it adds an error payload and replaces the infl
   const makeActionCreator = defineFetch({
     displayName: 'example action',
     make: testArg => ({
-      key: [testArg],
       request: () => ({ exampleService }) => exampleService(testArg),
     }),
   });

--- a/src/dataServiceReducer/sharedReducer.test.js
+++ b/src/dataServiceReducer/sharedReducer.test.js
@@ -25,7 +25,6 @@ test('returns the previous state if the action is not shared', () => {
   const actionCreatorFactory = defineFetch({
     displayName: 'test action',
     make: testArg => ({
-      key: [testArg],
       request: () => () => {},
     }),
   });
@@ -54,7 +53,6 @@ test('clear fetch', () => {
     displayName: 'Get People',
     share: { namespace: 'people' },
     make: personId => ({
-      key: [personId],
       request: () => () => ({ id: personId, foo: 'bar' }),
     }),
   });

--- a/src/defineFetch/defineFetch.d.ts
+++ b/src/defineFetch/defineFetch.d.ts
@@ -19,7 +19,7 @@ export interface DefineFetchParams<
   displayName: string;
   make: (
     ...keyArgs: KeyArgs
-  ) => { key: string[]; request: (...fetchArgs: FetchArgs) => (services: any) => FetchResult };
+  ) => { request: (...fetchArgs: FetchArgs) => (services: any) => FetchResult };
   share?: ShareParams<MergeResult>;
   conflict?: 'cancel' | 'ignore';
   staticFetchFactoryId?: string;

--- a/src/defineFetch/defineFetch.js
+++ b/src/defineFetch/defineFetch.js
@@ -8,21 +8,26 @@ export function isFetchAction(action) {
   return action.type.startsWith(FETCH);
 }
 
-function memoize(actionCreatorFactory, make, conflict) {
+function memoize(displayName, actionCreatorFactory, make, conflict) {
   // TODO: may need a way to clear this memo
   const memo = {};
 
   function memoized(...keyArgs) {
-    const keyResult = make(...keyArgs);
+    const makeResult = make(...keyArgs);
 
-    if (typeof keyResult !== 'object') {
+    if (typeof makeResult !== 'object') {
       throw new Error('[defineFetch]: `make` must return an object');
     }
 
-    const { key, request } = keyResult;
+    const { request } = makeResult;
 
-    if (!Array.isArray(key)) {
-      throw new Error('[defineFetch] `key` must be an array in the object that `make` returns');
+    if (!keyArgs.every(key => typeof key === 'string' || typeof key === 'number')) {
+      const rogueKey = keyArgs.find(key => typeof key !== 'string' && typeof key !== 'number');
+      throw new Error(
+        `[defineFetch] make arguments must be either a string or a number. Found "${JSON.stringify(
+          rogueKey,
+        )}" for the fetch factory "${displayName}"`,
+      );
     }
     if (typeof request !== 'function') {
       throw new Error(
@@ -30,7 +35,7 @@ function memoize(actionCreatorFactory, make, conflict) {
       );
     }
 
-    const hash = `key:${[...key, conflict].join(' | ')}`;
+    const hash = `key:${[...keyArgs, conflict].join(' | ')}`;
 
     if (memo[hash]) {
       return memo[hash];
@@ -60,7 +65,7 @@ export default function defineFetch({
 
     const meta = {
       fetchFactoryId,
-      key: `key:${makeResult.key.join(' | ')}`,
+      key: `key:${keyArgs.join(' | ')}`,
       displayName,
       share,
       conflict,
@@ -115,7 +120,7 @@ export default function defineFetch({
     return fetch;
   }
 
-  const memoizedFetchFactory = memoize(fetchFactory, make, conflict);
+  const memoizedFetchFactory = memoize(displayName, fetchFactory, make, conflict);
 
   memoizedFetchFactory.meta = {
     fetchFactoryId,

--- a/src/defineFetch/defineFetch.test.js
+++ b/src/defineFetch/defineFetch.test.js
@@ -47,18 +47,18 @@ describe('defineFetch', () => {
     }).toThrowErrorMatchingInlineSnapshot(`"[defineFetch]: \`make\` must return an object"`);
   });
 
-  test('it throws if there is no `key`', () => {
+  test("it throws if the make args aren't strings or numbers", () => {
     expect(() => {
       const actionCreatorFactory = defineFetch({
         displayName: 'something',
         make: id => ({
-          noKey: [id],
+          request: () => () => {},
         }),
       });
 
-      actionCreatorFactory('test-id');
+      actionCreatorFactory(null);
     }).toThrowErrorMatchingInlineSnapshot(
-      `"[defineFetch] \`key\` must be an array in the object that \`make\` returns"`,
+      `"[defineFetch] make arguments must be either a string or a number. Found \\"null\\" for the fetch factory \\"something\\""`,
     );
   });
 

--- a/src/defineFetch/defineFetch.test.js
+++ b/src/defineFetch/defineFetch.test.js
@@ -26,7 +26,6 @@ describe('defineFetch', () => {
     const actionCreatorFactory = defineFetch({
       displayName: 'something',
       make: id => ({
-        key: [id],
         request: () => ({ exampleService }) => exampleService(),
       }),
     });
@@ -67,7 +66,6 @@ describe('defineFetch', () => {
       const actionCreatorFactory = defineFetch({
         displayName: 'something',
         make: id => ({
-          key: [id],
           request: 'not a function',
         }),
       });
@@ -82,7 +80,6 @@ describe('defineFetch', () => {
     const makeFetch = defineFetch({
       displayName: 'Example',
       make: () => ({
-        key: [],
         request: () => 'not a function',
       }),
     });
@@ -100,7 +97,6 @@ describe('defineFetch', () => {
     const actionCreatorFactory = defineFetch({
       displayName: 'example fetch',
       make: id => ({
-        key: [id],
         request: () => ({ exampleService }) => exampleService(),
       }),
     });
@@ -124,7 +120,6 @@ describe('defineFetch', () => {
     const actionCreatorFactory = defineFetch({
       displayName: 'example payload',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(testArg),
       }),
     });
@@ -143,7 +138,6 @@ describe('defineFetch', () => {
     const actionCreatorFactory = defineFetch({
       displayName: 'example payload',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(testArg),
       }),
     });
@@ -176,7 +170,6 @@ describe('defineFetch', () => {
     const makeActionCreator = defineFetch({
       displayName: 'action creator',
       make: id => ({
-        key: [id],
         request: () => () => {},
       }),
     });
@@ -204,7 +197,6 @@ describe('isFetchAction', () => {
     const actionCreatorFactory = defineFetch({
       displayName: 'test fetch',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(),
       }),
     });

--- a/src/defineFetch/defineFetch.types-test.ts
+++ b/src/defineFetch/defineFetch.types-test.ts
@@ -7,7 +7,6 @@ const exampleResult = {
 const actionCreatorFactory = defineFetch({
   displayName: 'example fetch',
   make: (foo: string, bar: number) => ({
-    key: [foo, bar.toString()],
     request: () => ({  }: /* services go here */ any) => exampleResult,
   }),
 });

--- a/src/getFetch/getFetch.test.js
+++ b/src/getFetch/getFetch.test.js
@@ -161,7 +161,6 @@ describe('getFetch', () => {
       const actionCreator = defineFetch({
         displayName: 'Test',
         make: () => ({
-          key: [],
           request: () => () => {},
         }),
       });
@@ -177,7 +176,6 @@ describe('getFetch', () => {
       const actionCreator = defineFetch({
         displayName: 'Test',
         make: () => ({
-          key: [],
           request: () => () => {},
         }),
       });
@@ -204,7 +202,6 @@ describe('getFetch', () => {
     const makeMyFetch = defineFetch({
       displayName: 'Get My Fetch',
       make: () => ({
-        key: [],
         request: () => () => {},
       }),
     });
@@ -231,7 +228,6 @@ describe('getFetch', () => {
     const makeExampleFetch = defineFetch({
       displayName: 'example fetch',
       make: testArg => ({
-        key: [testArg],
         request: () => ({ exampleService }) => exampleService(testArg),
       }),
     });
@@ -249,7 +245,6 @@ describe('getFetch', () => {
     const makeFetch = defineFetch({
       displayName: 'Example Fetch',
       make: () => ({
-        key: [],
         request: () => () => {},
       }),
     });
@@ -307,7 +302,6 @@ describe('getFetch', () => {
       displayName: 'My Fetch',
       share: { namespace: 'example' },
       make: () => ({
-        key: [],
         request: () => () => {},
       }),
     });
@@ -329,7 +323,6 @@ describe('getFetch', () => {
       displayName: 'Example',
       share: { namespace: 'example' },
       make: () => ({
-        key: [],
         request: () => () => ({ foo: 'bar' }),
       }),
     });
@@ -408,7 +401,6 @@ describe('getFetch', () => {
       displayName: 'Example One',
       share: { namespace: 'example' },
       make: () => ({
-        key: [],
         request: () => () => {},
       }),
     });
@@ -417,7 +409,6 @@ describe('getFetch', () => {
       displayName: 'Example Two',
       share: { namespace: 'example' },
       make: () => ({
-        key: [],
         request: () => () => {},
       }),
     });

--- a/src/getFetch/getFetch.types-test.ts
+++ b/src/getFetch/getFetch.types-test.ts
@@ -15,7 +15,6 @@ import defineFetch from '../defineFetch';
   const actionCreatorFactory = defineFetch({
     displayName: 'test',
     make: (personId: string) => ({
-      key: [personId],
       request: (_: Person) => () => exampleObject,
     }),
   });
@@ -52,7 +51,6 @@ import defineFetch from '../defineFetch';
       merge: (previous, next) => exampleObject,
     },
     make: (personId: string) => ({
-      key: [personId],
       request: (_: Person) => () => anotherExampleObject,
     }),
   });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -18,7 +18,6 @@ test('basic lifecycle', async () => {
   const makePersonFetch = defineFetch({
     displayName: 'Get Person',
     make: personId => ({
-      key: [personId],
       request: () => () => ({
         personId,
         name: 'It worked!',

--- a/src/useClearFetch/useClearFetch.test.js
+++ b/src/useClearFetch/useClearFetch.test.js
@@ -15,7 +15,6 @@ test('it returns a function that calls dispatch', () => {
   const makePersonFetch = defineFetch({
     displayName: 'fetch person',
     make: personId => ({
-      key: [personId],
       request: () => ({ exampleService }) => exampleService(),
     }),
   });

--- a/src/useDispatch/useDispatch.test.js
+++ b/src/useDispatch/useDispatch.test.js
@@ -133,7 +133,6 @@ test('throws when you dispatch a fetch instance instead of calling it', async ()
   const makeFetch = defineFetch({
     displayName: 'Example',
     make: () => ({
-      key: [],
       request: () => () => {},
     }),
   });
@@ -186,7 +185,6 @@ test('throws when you dispatch a fetch factory', async () => {
   const makeFetch = defineFetch({
     displayName: 'Example',
     make: () => ({
-      key: [],
       request: () => () => {},
     }),
   });

--- a/src/useFetch/useFetch.test.js
+++ b/src/useFetch/useFetch.test.js
@@ -18,7 +18,6 @@ test('it gets the fetch and returns the data and status', () => {
   const makePersonFetch = defineFetch({
     displayName: 'fetch person',
     make: personId => ({
-      key: [personId],
       request: () => ({ exampleService }) => exampleService(personId),
     }),
   });
@@ -75,7 +74,6 @@ test('it bails out of updating if the data does not change', () => {
   const makePersonFetch = defineFetch({
     displayName: 'fetch person',
     make: personId => ({
-      key: [personId],
       request: () => ({ exampleService }) => exampleService(personId),
     }),
   });
@@ -83,7 +81,6 @@ test('it bails out of updating if the data does not change', () => {
   const makeOtherFetch = defineFetch({
     displayName: 'fetch other',
     make: otherId => ({
-      key: [otherId],
       request: () => ({ exampleService }) => exampleService(otherId),
     }),
   });


### PR DESCRIPTION
Implements #14 

This also adds enforces that the arguments to `make` are only strings and numbers. Nothing else is allowed when invoking a fetch factory.